### PR TITLE
chore: remove duplicated use dockerbuildx

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -32,9 +32,6 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      - uses: crazy-max/ghaction-docker-buildx@v1
-        if: ${{ github.event_name != 'pull_request' }}
-
       - name: Dev
         if: ${{ github.ref == 'refs/heads/master'}}
         run: |


### PR DESCRIPTION
`uses: crazy-max/ghaction-docker-buildx@v1`  was set as global and throws error if inited twice :(