### PR TITLE
fix: crash on undefined packet in ack event

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -360,7 +360,7 @@ async function start (program) {
 
   // QoS 1 or 2 acknowledgement when the packet successfully delivered to the client
   broker.on('ack', function (packet, client) {
-    logger.debug('ACK of %s received from client \x1b[33m%s\x1b[0m, broker %s', packet.topic, (client ? client.id : client), broker.id)
+    logger.debug('ACK of %s received from client \x1b[33m%s\x1b[0m, broker %s', packet ? packet.topic : packet, (client ? client.id : client), broker.id)
   })
 
   // when client sends a PINGREQ


### PR DESCRIPTION
I am observing frequent crashes of aedes-cli in my environment
* openzwave
* zwave2mqtt
* aedes
* android app MyMQTT subscribing for all topics by specifying '#'

As soon MyMQTT or openzwave are not part of the setup, runs aedes without issues.

Aedes crashes because `packet` is undefined.