### PR TITLE
fail for not authorized subscribe

### DIFF
--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -59,7 +59,7 @@ Authorizer.prototype.authorizePublish = function () {
 Authorizer.prototype.authorizeSubscribe = function () {
   const that = this
   return function (client, sub, cb) {
-    cb(null, minimatch(sub.topic, that._users.get(client.user).authorizeSubscribe || defaultGlob) ? sub : null)
+    minimatch(sub.topic, that._users.get(client.user).authorizeSubscribe || defaultGlob) ? cb(null, sub) : cb(Error('Subscribe not authorized'))
   }
 }
 

--- a/test/authorizer.test.js
+++ b/test/authorizer.test.js
@@ -43,9 +43,12 @@ test('add user and authenticate/authorize', async function (t) {
   await authorizePub(client, allowed)
   t.pass('should authorize pub on allowed topics')
 
-  res = await authorizeSub(client, notAllowed)
-  t.equal(res, null, 'should not authorize sub on not allowed topics')
-
+  try {
+    res = await authorizeSub(client, notAllowed)
+  }catch (error) {
+    t.equal(error.message, 'Subscribe not authorized', 'should not authorize sub on not allowed topics')
+  }
+  
   res = await authorizeSub(client, allowed)
   t.same(res, allowed, 'should authorize sub on allowed topics')
 


### PR DESCRIPTION
not authorized subscribe attempts must generate an error

Not sure this is the solution you had in mind.  Even though it works it does generate a lot of noise in the logs when the subscribe is retried (eg mosquitto_sub will loop trough CONNECT, fail to subscribe and DISCONNECT till you interrupt the command)